### PR TITLE
Make module path valid.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module tsplot
+module github.com/bitly/tsplot
 
 go 1.14
 

--- a/tscli/main.go
+++ b/tscli/main.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"tsplot/tsplot"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"github.com/bitly/tsplot/tsplot"
 	"github.com/spf13/cobra"
 	"golang.org/x/image/colornames"
 	"gonum.org/v1/plot/vg"


### PR DESCRIPTION
https://pkg.go.dev complains that the module path is invalid. And
therefore not available on the site. This PR updates the module path to
be a valid one.
