### PR TITLE
adjust color set for visibility

### DIFF
--- a/tsplot/color_palettes.go
+++ b/tsplot/color_palettes.go
@@ -10,19 +10,19 @@ var usedColors = make(map[string]color.RGBA)
 
 // simple colors (subset of golang.org/x/image/colornames)
 var availableColors = map[string]color.RGBA{
-	"aqua":            color.RGBA{0x00, 0xff, 0xff, 0xff}, //(rgb: 0, 255, 255),
+	"navy":            color.RGBA{0x00, 0x00, 0x80, 0xff}, // rgb(0, 0, 128)
 	"brown":           color.RGBA{0xa5, 0x2a, 0x2a, 0xff}, // rgb(165, 42, 42)
+	"crimson":         color.RGBA{0xdc, 0x14, 0x3c, 0xff}, // rgb(220, 20, 60)
 	"darkkhaki":       color.RGBA{0xbd, 0xb7, 0x6b, 0xff}, // rgb(189, 183, 107)
 	"deepskyblue":     color.RGBA{0x00, 0xbf, 0xff, 0xff}, //(rgb: 0, 191, 255),
-	"gold":            color.RGBA{0xff, 0xd7, 0x00, 0xff}, //(rgb: 255, 215, 0),
+	"goldenrod":       color.RGBA{0xda, 0xa5, 0x20, 0xff}, // rgb(218, 165, 32)
 	"gray":            color.RGBA{0x80, 0x80, 0x80, 0xff}, // rgb(128, 128, 128)
 	"green":           color.RGBA{0x00, 0x80, 0x00, 0xff}, //(rgb: 0, 128, 0),
-	"lime":            color.RGBA{0x00, 0xff, 0x00, 0xff}, //(rgb: 0, 255, 0),
+	"limegreen":       color.RGBA{0x32, 0xcd, 0x32, 0xff}, // rgb(50, 205, 50)
 	"magenta":         color.RGBA{0xff, 0x00, 0xff, 0xff}, //(rgb: 255, 0, 255),
 	"mediumturquoise": color.RGBA{0x48, 0xd1, 0xcc, 0xff}, // rgb(72, 209, 204)
-	"orange":          color.RGBA{0xff, 0xa5, 0x00, 0xff}, //(rgb: 255, 165, 0),
+	"orangered":       color.RGBA{0xff, 0x45, 0x00, 0xff}, // rgb(255, 69, 0)
 	"purple":          color.RGBA{0x80, 0x00, 0x80, 0xff}, // rgb(128, 0, 128)
-	"red":             color.RGBA{0xff, 0x00, 0x00, 0xff}, //(rgb: 255, 0, 0),
 	"royalblue":       color.RGBA{0x41, 0x69, 0xe1, 0xff}, // rgb(65, 105, 225)
 	"violet":          color.RGBA{0xee, 0x82, 0xee, 0xff}, //(rgb: 238, 130, 238),
 }


### PR DESCRIPTION
Swap some colors from the color set to allow for visibility of chart lines. 