### PR TITLE
add sans serif font, adjust legend padding

### DIFF
--- a/tsplot/options.go
+++ b/tsplot/options.go
@@ -94,6 +94,16 @@ func WithFontSize(size float64) PlotOption {
 	}
 }
 
+// WithFontSize configures the font variant as Sans-Serif
+func WithSansFont() PlotOption {
+	return func(p *plot.Plot) {
+		p.Title.TextStyle.Font.Variant = "Sans"
+		p.X.Label.TextStyle.Font.Variant = "Sans"
+		p.Y.Label.TextStyle.Font.Variant = "Sans"
+		p.Legend.TextStyle.Font.Variant = "Sans"
+	}
+}
+
 // ApplyDefaultHighContrast applies the default high contrast color scheme to the *plot.Plot.
 func ApplyDefaultHighContrast(p *plot.Plot) {
 	opts := []PlotOption{

--- a/tsplot/plot.go
+++ b/tsplot/plot.go
@@ -6,6 +6,7 @@ import (
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"gonum.org/v1/plot"
 	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/vg"
 	"google.golang.org/api/iterator"
 	"google.golang.org/genproto/googleapis/api/metric"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
@@ -108,6 +109,7 @@ func NewPlotFromTimeSeriesIterator(tsi *monitoring.TimeSeriesIterator, legendKey
 			legendEntry.Color = lineColor
 			p.Legend.Left = true
 			p.Legend.Top = true
+			p.Legend.Padding = vg.Points(2)
 			p.Legend.Add(timeSeries.GetMetric().GetLabels()[legendKey], legendEntry)
 		}
 	}


### PR DESCRIPTION
This PR makes some minor formatting changes, creating the option to use sans-serif font, and slightly increasing the padding between legend entries.