### PR TITLE
chore: add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Adds a Dependabot configuration that keeps GitHub Actions references up to date.

## Details

- Creates `.github/dependabot.yml` with the `github-actions` package ecosystem.
- Dependabot will scan workflow files under `/` (i.e. `.github/workflows/`) and open PRs to bump action versions.
- Runs on a `weekly` schedule.

Once merged, Dependabot will automatically open pull requests whenever a newer version of any referenced GitHub Action is available.
